### PR TITLE
Removing the master-slave vocabulary

### DIFF
--- a/ETROC1_SinglePixel_Test/ETROC1_SinglePixel_Test_Software/ETROC1_SinglePixel_Control.py
+++ b/ETROC1_SinglePixel_Test/ETROC1_SinglePixel_Test_Software/ETROC1_SinglePixel_Control.py
@@ -72,14 +72,14 @@ def test_ddr3(data_num):
         data_out += cmd_interpret.read_data_fifo(50000)           # reading start
     return data_out
 #--------------------------------------------------------------------------#
-## IIC write slave device
+## IIC write subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0] : slave device address
+# @param subordinate[7:0] : subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
 # @param data[7:0] : 8-bit write data
-def iic_write(mode, slave_addr, wr, reg_addr, data):
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | data
+def iic_write(mode, subordinate_addr, wr, reg_addr, data):
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | data
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -87,19 +87,19 @@ def iic_write(mode, slave_addr, wr, reg_addr, data):
     time.sleep(0.01)
     # print(hex(val))
 #--------------------------------------------------------------------------#
-## IIC read slave device
+## IIC read subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0]: slave device address
+# @param subordinate[7:0]: subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
-def iic_read(mode, slave_addr, wr, reg_addr):
-    val = mode << 24 | slave_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
+def iic_read(mode, subordinate_addr, wr, reg_addr):
+    val = mode << 24 | subordinate_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
     cmd_interpret.write_pulse_reg(0x0001)				                      # Sent a pulse to IIC module
 
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -117,7 +117,7 @@ def Enable_FPGA_Descramblber(val):
 #--------------------------------------------------------------------------#
 ## main functionl
 def main():
-    slave_addr = 0x4E                                               # I2C slave address
+    subordinate_addr = 0x4E                                               # I2C subordinate address
     reg_val = []
     ETROC1_SinglePixelReg1 = ETROC1_SinglePixelReg()                # New a class
     reg_val = ETROC1_SinglePixelReg1.get_config_vector()            # Get Single Pixel Register default data
@@ -125,12 +125,12 @@ def main():
     print("I2C write in data:")
     print(reg_val)
     for i in range(len(reg_val)):                                   # Write data into I2C register
-        iic_write(1, slave_addr, 0, i, int(reg_val[i], 16))
+        iic_write(1, subordinate_addr, 0, i, int(reg_val[i], 16))
     time.sleep(0.1)
 
     iic_read_val = []
     for i in range(len(reg_val)):                                   # Read back I2C register value
-        iic_read_val += [iic_read(0, slave_addr, 1, i)]
+        iic_read_val += [iic_read(0, subordinate_addr, 1, i)]
     print("I2C read back data:")
     print(iic_read_val)
     print("Ok!")

--- a/ETROC1_TDC_Test/ETROC1_TDC_Test_Software/TDC_I2C_GUI/TDC_I2C.py
+++ b/ETROC1_TDC_Test/ETROC1_TDC_Test_Software/TDC_I2C_GUI/TDC_I2C.py
@@ -21,16 +21,16 @@ This script is used for testing ETROC1 TDC chip. The mianly function of this scr
 '''
 hostname = '192.168.2.3'					#FPGA IP address
 port = 1024									#port number
-I2C_Slave_Addr = 0x22
+I2C_Subordinate_Addr = 0x22
 #--------------------------------------------------------------------------#
-## IIC write slave device
+## IIC write subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0] : slave device address
+# @param subordinate[7:0] : subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
 # @param data[7:0] : 8-bit write data
-def iic_write(mode, slave_addr, wr, reg_addr, data):
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | data
+def iic_write(mode, subordinate_addr, wr, reg_addr, data):
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | data
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -38,19 +38,19 @@ def iic_write(mode, slave_addr, wr, reg_addr, data):
     time.sleep(0.01)
     # print(hex(val))
 #--------------------------------------------------------------------------#
-## IIC read slave device
+## IIC read subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0]: slave device address
+# @param subordinate[7:0]: subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
-def iic_read(mode, slave_addr, wr, reg_addr):
-    val = mode << 24 | slave_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
+def iic_read(mode, subordinate_addr, wr, reg_addr):
+    val = mode << 24 | subordinate_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
     cmd_interpret.write_pulse_reg(0x0001)				                      # Sent a pulse to IIC module
 
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -716,12 +716,12 @@ class Ui_ETROC1_TDC_TEST_GUI(object):
         font.setWeight(75)
         self.I2C_Configuration_Label.setFont(font)
         self.I2C_Configuration_Label.setObjectName("I2C_Configuration_Label")
-        self.Slave_Addr_Label = QtWidgets.QLabel(self.centralwidget)
-        self.Slave_Addr_Label.setGeometry(QtCore.QRect(85, 710, 71, 21))
+        self.Subordinate_Addr_Label = QtWidgets.QLabel(self.centralwidget)
+        self.Subordinate_Addr_Label.setGeometry(QtCore.QRect(85, 710, 71, 21))
         font = QtGui.QFont()
         font.setPointSize(10)
-        self.Slave_Addr_Label.setFont(font)
-        self.Slave_Addr_Label.setObjectName("Slave_Addr_Label")
+        self.Subordinate_Addr_Label.setFont(font)
+        self.Subordinate_Addr_Label.setObjectName("Subordinate_Addr_Label")
         self.Salve_Addr = QtWidgets.QComboBox(self.centralwidget)
         self.Salve_Addr.setGeometry(QtCore.QRect(158, 710, 51, 22))
         self.Salve_Addr.setObjectName("Salve_Addr")
@@ -860,18 +860,18 @@ class Ui_ETROC1_TDC_TEST_GUI(object):
         self.Pulse_Sel_Label.setText(_translate("ETROC1_TDC_TEST_GUI", "Pulse_Sel[7:0]"))
         self.TDCRawData_Sel_Label.setText(_translate("ETROC1_TDC_TEST_GUI", "TDCRawData_Sel"))
         self.I2C_Configuration_Label.setText(_translate("ETROC1_TDC_TEST_GUI", "I2C Configuration"))
-        self.Slave_Addr_Label.setText(_translate("ETROC1_TDC_TEST_GUI", "Slave_Addr"))
+        self.Subordinate_Addr_Label.setText(_translate("ETROC1_TDC_TEST_GUI", "Subordinate_Addr"))
         self.Salve_Addr.setItemText(0, _translate("ETROC1_TDC_TEST_GUI", "0x22"))
         self.Salve_Addr.setItemText(1, _translate("ETROC1_TDC_TEST_GUI", "0x23"))
 
     def Salve_Addr_currentIndexChanged(self):
         winsound.Beep(1000, 100)
         if self.Salve_Addr.currentText() == "0x22":
-            I2C_Slave_Addr = 0x22
-            print("I2C Slave address: 0x22")
+            I2C_Subordinate_Addr = 0x22
+            print("I2C Subordinate address: 0x22")
         else:
-            I2C_Slave_Addr = 0x22
-            print("I2C Slave address: 0x23")
+            I2C_Subordinate_Addr = 0x22
+            print("I2C Subordinate address: 0x23")
 
     def Pulse_enableRx_valueChanged(self):
         winsound.Beep(1000, 100)
@@ -1095,11 +1095,11 @@ class Ui_ETROC1_TDC_TEST_GUI(object):
         print("TDC I2C Write in data:")
         print(TDC_I2C_Reg)
         for i in range(len(TDC_I2C_Reg)):
-            iic_write(1, I2C_Slave_Addr, 0, i, TDC_I2C_Reg[i])
+            iic_write(1, I2C_Subordinate_Addr, 0, i, TDC_I2C_Reg[i])
         print("TDC I2C Read back data:")
         iic_read_val = []
         for j in range(len(TDC_I2C_Reg)):
-            iic_read_val += [iic_read(0, I2C_Slave_Addr, 1, j)]
+            iic_read_val += [iic_read(0, I2C_Subordinate_Addr, 1, j)]
         print(iic_read_val)
 
 if __name__ == "__main__":

--- a/ETROC1_TDC_Test/ETROC1_TDC_Test_Software/kc705_mig_control.py
+++ b/ETROC1_TDC_Test/ETROC1_TDC_Test_Software/kc705_mig_control.py
@@ -72,14 +72,14 @@ def test_ddr3(data_num):
         data_out += cmd_interpret.read_data_fifo(50000)           # reading start
     return data_out
 #--------------------------------------------------------------------------#
-## IIC write slave device
+## IIC write subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0] : slave device address
+# @param subordinate[7:0] : subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
 # @param data[7:0] : 8-bit write data
-def iic_write(mode, slave_addr, wr, reg_addr, data):
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | data
+def iic_write(mode, subordinate_addr, wr, reg_addr, data):
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | data
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -87,19 +87,19 @@ def iic_write(mode, slave_addr, wr, reg_addr, data):
     time.sleep(0.01)
     # print(hex(val))
 #--------------------------------------------------------------------------#
-## IIC read slave device
+## IIC read subordinate device
 # @param mode[1:0] : '0'is 1 bytes read or wirte, '1' is 2 bytes read or write, '2' is 3 bytes read or write
-# @param slave[7:0]: slave device address
+# @param subordinate[7:0]: subordinate device address
 # @param wr: 1-bit '0' is write, '1' is read
 # @param reg_addr[7:0] : register address
-def iic_read(mode, slave_addr, wr, reg_addr):
-    val = mode << 24 | slave_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
+def iic_read(mode, subordinate_addr, wr, reg_addr):
+    val = mode << 24 | subordinate_addr << 17 |  0 << 16 | reg_addr << 8 | 0x00	  # write device addr and reg addr
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
     cmd_interpret.write_pulse_reg(0x0001)				                      # Sent a pulse to IIC module
 
-    val = mode << 24 | slave_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
+    val = mode << 24 | subordinate_addr << 17 | wr << 16 | reg_addr << 8 | 0x00	  # write device addr and read one byte
     cmd_interpret.write_config_reg(4, 0xffff & val)
     cmd_interpret.write_config_reg(5, 0xffff & (val>>16))
     time.sleep(0.01)
@@ -114,7 +114,7 @@ def Enable_FPGA_Descrablber(val):
 #--------------------------------------------------------------------------#
 ## main functionl
 def main():
-    slave_addr = 0x23                                       # I2C slave address
+    subordinate_addr = 0x23                                       # I2C subordinate address
     reg_val = []
     ETROC1_TDCReg1 = ETROC1_TDCReg()
 
@@ -125,7 +125,7 @@ def main():
     print("I2C write in data:")
     print(reg_val)
     for i in range(len(reg_val)):
-        iic_write(1, slave_addr, 0, i, reg_val[i])
+        iic_write(1, subordinate_addr, 0, i, reg_val[i])
     time.sleep(0.1)
 
     ## GRO Test Contorl
@@ -173,10 +173,10 @@ def main():
     print("I2C write in data:")
     print(reg_val)
     for i in range(len(reg_val)):
-        iic_write(1, slave_addr, 0, i, reg_val[i])
+        iic_write(1, subordinate_addr, 0, i, reg_val[i])
     iic_read_val = []
     for i in range(len(reg_val)):
-        iic_read_val += [iic_read(0, slave_addr, 1, i)]
+        iic_read_val += [iic_read(0, subordinate_addr, 1, i)]
     print("I2C read back data:")
     print(iic_read_val)
     print("Ok!")
@@ -184,7 +184,7 @@ def main():
     readonly_reg = [0x21, 0x22, 0x23, 0x24]
     readonly_val = []
     for i in range(len(readonly_reg)):
-        readonly_val += [iic_read(0, slave_addr, 1, readonly_reg[i])]
+        readonly_val += [iic_read(0, subordinate_addr, 1, readonly_reg[i])]
     print(readonly_val)
     TOA_Code = (readonly_val[2] & 0x7) << 7 | ((readonly_val[1] >> 1) & 0x7f)
     TOT_Code = (readonly_val[1] & 0x1) << 8 | readonly_val[0]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.